### PR TITLE
Update default settings

### DIFF
--- a/tensorflow_cloud/run.py
+++ b/tensorflow_cloud/run.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Module that contains the `run` API for scaling Keras/Tensorflow jobs."""
+"""Module that contains the `run` API for scaling Keras/TensorFlow jobs."""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -48,7 +48,7 @@ def run(entry_point=None,
             If `entry_point` is not provided, then the current python script is
             assumed to be the `entry_point`.
         requirements_txt: Optional string. File path to requirements.txt file
-            containing aditional pip dependencies if any. ie. a file with a
+            containing additional pip dependencies if any. ie. a file with a
             list of pip dependency package names.
             Note: This path must be in the current working directory tree.
             Example: 'requirements.txt', 'deps/reqs.txt'
@@ -63,14 +63,14 @@ def run(entry_point=None,
                 `tf.distribute.MirroredStrategy`
             - Otherwise, we will use `tf.distribute.OneDeviceStrategy`
             If you have created a distribution strategy instance in your script
-            already, please set `distribution_stratgey` as None here.
+            already, please set `distribution_strategy` as None here.
             For example, if you are using `tf.keras` custom training loops,
             you will need to create a strategy in the script for distributing
             the dataset.
         docker_base_image: Optional base docker image to use. Defaults to None.
             Example: 'gcr.io/my_gcp_project/deep_learning:v2'
             If a base docker image is not provided here, we will use a
-            Tensorflow docker image (https://www.tensorflow.org/install/docker)
+            TensorFlow docker image (https://www.tensorflow.org/install/docker)
             as the base image. The version of TensorFlow and Python in that
             case will match your local environment.
             If both docker_base_image and a local TF installation are not

--- a/tests/integration/call_run_on_notebook_with_keras_fit.py
+++ b/tests/integration/call_run_on_notebook_with_keras_fit.py
@@ -25,6 +25,6 @@ tfc.run(
     chief_config=tfc.MachineConfig(
             cpu_cores=8,
             memory=30,
-            accelerator_type=tfc.AcceleratorType.NVIDIA_TESLA_P100,
+            accelerator_type=tfc.AcceleratorType.NVIDIA_TESLA_T4,
             accelerator_count=2),
     worker_count=0)

--- a/tests/integration/call_run_on_script_with_keras_fit.py
+++ b/tests/integration/call_run_on_script_with_keras_fit.py
@@ -36,12 +36,13 @@ import tensorflow_cloud as tfc
 # Automated MirroredStrategy: chief config with multiple GPUs
 tfc.run(
     entry_point='tests/testdata/mnist_example_using_fit.py',
+    docker_base_image='gcr.io/deeplearning-platform-release/tf2-gpu',
     distribution_strategy='auto',
     requirements_txt='tests/testdata/requirements.txt',
     chief_config=tfc.MachineConfig(
             cpu_cores=8,
             memory=30,
-            accelerator_type=tfc.AcceleratorType.NVIDIA_TESLA_P100,
+            accelerator_type=tfc.AcceleratorType.NVIDIA_TESLA_T4,
             accelerator_count=2),
     worker_count=0,
     stream_logs=True)

--- a/tests/integration/call_run_within_script_with_keras_fit.py
+++ b/tests/integration/call_run_within_script_with_keras_fit.py
@@ -19,7 +19,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import os
 
 import tensorflow_datasets as tfds
 import tensorflow as tf
@@ -38,7 +37,7 @@ tfc.run(
     chief_config=tfc.MachineConfig(
             cpu_cores=8,
             memory=30,
-            accelerator_type=tfc.AcceleratorType.NVIDIA_TESLA_P100,
+            accelerator_type=tfc.AcceleratorType.NVIDIA_TESLA_T4,
             accelerator_count=2),
     worker_count=0)
 


### PR DESCRIPTION
1. Cloud AI started recommending users to use NVIDIA T4 for cost efficiency for
both training and serving and AMP(Automatic Mixed Precision) [support](https://cloud.google.com/blog/products/ai-machine-learning/your-ml-workloads-cheaper-and-faster-with-the-latest-gpus)
2. Update instance sample to [Google Cloud Deep Learning container](https://cloud.google.com/ai-platform/deep-learning-containers) using TensorFlow Enterprise
3. Typos