### PR TITLE
Fix docker build logs decode error

### DIFF
--- a/tests/tensorflow_cloud/containerize_test.py
+++ b/tests/tensorflow_cloud/containerize_test.py
@@ -360,7 +360,7 @@ class TestContainerize(unittest.TestCase):
         self.assertEqual(docker_client.push.call_count, 1)
         args, kwargs = docker_client.push.call_args
         self.assertListEqual(list(args), [img_tag])
-        self.assertDictEqual(kwargs, {"stream": True})
+        self.assertDictEqual(kwargs, {"decode": True, "stream": True})
 
         # Verify logger info calls.
         self.assertEqual(MockLogger.info.call_count, 2)


### PR DESCRIPTION
When trying out the example in the README I ran into the following JSON decode error during the local docker build since the logger couldn't decode `{"stream":"\n"}`:
```python-traceback
INFO:tensorflow_cloud.containerize:Building docker image: gcr.io/bnn-research/tf_cloud_train:6040dde0_5626_4e5a_b4c4_1b13d427c421
INFO:tensorflow_cloud.containerize:{"stream":"Step 1/6 : FROM tensorflow/tensorflow:2.2.0-gpu"}
{"stream":"\n"}
Traceback (most recent call last):
  File "/Users/lukasgeiger/code/cloud/tensorflow_cloud/containerize.py", line 304, in _get_logs
    line = json.loads(unicode_line)
  File "/usr/local/Cellar/python/3.7.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/json/__init__.py", line 348, in loads
    return _default_decoder.decode(s)
  File "/usr/local/Cellar/python/3.7.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/json/decoder.py", line 340, in decode
    raise JSONDecodeError("Extra data", s, end)
json.decoder.JSONDecodeError: Extra data: line 2 column 1 (char 62)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "example.py", line 6, in <module>
    requirements_txt="requirements.txt",
  File "/Users/lukasgeiger/code/cloud/tensorflow_cloud/run.py", line 211, in run
    docker_img_uri = container_builder.get_docker_image()
  File "/Users/lukasgeiger/code/cloud/tensorflow_cloud/containerize.py", line 251, in get_docker_image
    image_uri = self._build_docker_image()
  File "/Users/lukasgeiger/code/cloud/tensorflow_cloud/containerize.py", line 272, in _build_docker_image
    self._get_logs(bld_logs_generator, "build")
  File "/Users/lukasgeiger/code/cloud/tensorflow_cloud/containerize.py", line 312, in _get_logs
    raise RuntimeError("There was an error decoding the Docker logs")
RuntimeError: There was an error decoding the Docker logs
```

Using the builtin decode function of the Docker API fixes the error.

This PR also changes the logging to only print the `stream` instead of the entire JSON dict which make the output a lot more readable in the example I tried.

Note: This is the first time I am trying out TensorFlow Cloud so I might miss some edge cases.