### PR TITLE
Copy code as last step of the container build

### DIFF
--- a/tensorflow_cloud/containerize.py
+++ b/tensorflow_cloud/containerize.py
@@ -144,13 +144,15 @@ class ContainerBuilder(object):
             "WORKDIR {}".format(self.destination_dir),
         ]
 
-        # Copies the files from the `destination_dir` in docker daemon location
-        # to the `destination_dir` in docker container filesystem.
-        lines.append("COPY {} {}".format(self.destination_dir, self.destination_dir))
-
         if self.requirements_txt is not None:
             _, requirements_txt_name = os.path.split(self.requirements_txt)
             dst_requirements_txt = os.path.join(requirements_txt_name)
+            requirements_txt_path = os.path.join(
+                self.destination_dir, requirements_txt_name
+            )
+            lines.append(
+                "COPY {} {}".format(requirements_txt_path, requirements_txt_path)
+            )
             # install pip requirements from requirements_txt if it exists.
             lines.append(
                 "RUN if [ -e {} ]; "
@@ -164,6 +166,10 @@ class ContainerBuilder(object):
             self.worker_config
         ):
             lines.append("RUN pip install cloud-tpu-client")
+
+        # Copies the files from the `destination_dir` in docker daemon location
+        # to the `destination_dir` in docker container filesystem.
+        lines.append("COPY {} {}".format(self.destination_dir, self.destination_dir))
 
         docker_entry_point = self.preprocessed_entry_point or self.entry_point
         _, docker_entry_point_file_name = os.path.split(docker_entry_point)

--- a/tests/tensorflow_cloud/containerize_test.py
+++ b/tests/tensorflow_cloud/containerize_test.py
@@ -87,9 +87,10 @@ class TestContainerize(unittest.TestCase):
         expected_docker_file_lines = [
             "FROM tensorflow/tensorflow:{}-gpu\n".format(VERSION),
             "WORKDIR /app/\n",
-            "COPY /app/ /app/\n",
+            "COPY /app/requirements.txt /app/requirements.txt\n",
             "RUN if [ -e requirements.txt ]; "
             "then pip install --no-cache -r requirements.txt; fi\n",
+            "COPY /app/ /app/\n",
             'ENTRYPOINT ["python", "mnist_example_using_fit.py"]',
         ]
         self.assert_docker_file(expected_docker_file_lines, lcb.docker_file_path)
@@ -177,8 +178,8 @@ class TestContainerize(unittest.TestCase):
         expected_docker_file_lines = [
             "FROM tensorflow/tensorflow:{}\n".format(VERSION),
             "WORKDIR /app/\n",
-            "COPY /app/ /app/\n",
             "RUN pip install cloud-tpu-client\n",
+            "COPY /app/ /app/\n",
             'ENTRYPOINT ["python", "mnist_example_using_fit.py"]',
         ]
         self.assert_docker_file(expected_docker_file_lines, lcb.docker_file_path)


### PR DESCRIPTION
The code is the main part that changes during model development. Copying the code to the Docker image before installing the dependencies prevents caching of the dependencies since all Docker layers need to be rebuilt if a previous one changes.
This PR changes the order of  the Docker file to copy the code as the last step so that dependencies only need to be reinstalled if the `requirements.txt` file changes. This speeds up local build times by a large amount since dependencies don't need to be reinstalled on every code change.