### PR TITLE
check base image exist before build

### DIFF
--- a/tensorflow_cloud/containerize.py
+++ b/tensorflow_cloud/containerize.py
@@ -156,9 +156,9 @@ class ContainerBuilder(object):
                 warnings.warn("Using TF nightly build.")
             else:
                 raise ValueError(
-                    "There is no docker base image corresponding to the local TF version: {}. Please provide docker_base_image or try with an other TF version.".format(
-                        VERSION
-                    )
+                    "There is no docker base image corresponding to the local "
+                    "TF version: {}. Please provide docker_base_image or try "
+                    "with an other TF version.".format(VERSION)
                 )
 
         lines = [

--- a/tensorflow_cloud/containerize.py
+++ b/tensorflow_cloud/containerize.py
@@ -142,15 +142,24 @@ class ContainerBuilder(object):
 
         if not self._base_image_exist():
             if "dev" in self.docker_base_image:
-                warnings.warn("Docker base image {} does not exist.".format(self.docker_base_image))
+                warnings.warn(
+                    "Docker base image {} does not exist.".format(
+                        self.docker_base_image
+                    )
+                )
                 newtag = "nightly"
                 if self.docker_base_image.endswith("-gpu"):
                     newtag += "-gpu"
-                self.docker_base_image = self.docker_base_image.split(":")[0] + ":" + newtag
+                self.docker_base_image = (
+                    self.docker_base_image.split(":")[0] + ":" + newtag
+                )
                 warnings.warn("Using TF nightly build.")
             else:
-                raise ValueError("Local TF version {} does not have available base image.".format(self.VERSION))
-
+                raise ValueError(
+                    "There is no docker base image corresponding to the local TF version: {}. Please provide docker_base_image or try with an other TF version.".format(
+                        VERSION
+                    )
+                )
 
         lines = [
             "FROM {}".format(self.docker_base_image),
@@ -247,8 +256,13 @@ class ContainerBuilder(object):
         use docker api v2 to check if base image is available.
         """
         repo_name, tag_name = self.docker_base_image.split(":")
-        r = requests.get("http://hub.docker.com/v2/repositories/{}/tags/{}".format(repo_name, tag_name))
+        r = requests.get(
+            "http://hub.docker.com/v2/repositories/{}/tags/{}".format(
+                repo_name, tag_name
+            )
+        )
         return r.ok
+
 
 class LocalContainerBuilder(ContainerBuilder):
     """Container builder that uses local docker daemon process."""

--- a/tensorflow_cloud/containerize.py
+++ b/tensorflow_cloud/containerize.py
@@ -23,6 +23,8 @@ import tarfile
 import tempfile
 import time
 import uuid
+import requests
+import warnings
 
 from . import machine_config
 from docker import APIClient
@@ -138,6 +140,18 @@ class ContainerBuilder(object):
             ):
                 self.docker_base_image += "-gpu"
 
+        if not self._base_image_exist():
+            if "dev" in self.docker_base_image:
+                warnings.warn("Docker base image {} does not exist.".format(self.docker_base_image))
+                newtag = "nightly"
+                if self.docker_base_image.endswith("-gpu"):
+                    newtag += "-gpu"
+                self.docker_base_image = self.docker_base_image.split(":")[0] + ":" + newtag
+                warnings.warn("Using TF nightly build.")
+            else:
+                raise ValueError("Local TF version {} does not have available base image.".format(self.VERSION))
+
+
         lines = [
             "FROM {}".format(self.docker_base_image),
             "WORKDIR {}".format(self.destination_dir),
@@ -228,6 +242,13 @@ class ContainerBuilder(object):
         unique_tag = str(uuid.uuid4()).replace("-", "_")
         return "{}/{}:{}".format(self.docker_registry, "tf_cloud_train", unique_tag)
 
+    def _base_image_exist(self):
+        """Check whether the docker base image exist on dockerhub. 
+        use docker api v2 to check if base image is available.
+        """
+        repo_name, tag_name = self.docker_base_image.split(":")
+        r = requests.get("http://hub.docker.com/v2/repositories/{}/tags/{}".format(repo_name, tag_name))
+        return r.ok
 
 class LocalContainerBuilder(ContainerBuilder):
     """Container builder that uses local docker daemon process."""

--- a/tests/tensorflow_cloud/containerize_test.py
+++ b/tests/tensorflow_cloud/containerize_test.py
@@ -163,7 +163,6 @@ class TestContainerize(unittest.TestCase):
         self.assert_docker_file(expected_docker_file_lines, lcb.docker_file_path)
         self.cleanup(lcb.docker_file_path)
 
-
     def test_create_docker_file_with_docker_base_image(self):
         self.setup()
         lcb = containerize.LocalContainerBuilder(


### PR DESCRIPTION
The container by default uses the TF version of local environment. This causes build fail when local version of TF does not have corresponding base image. It may be good to check before build, especially for cloud build. 

Also, using local TF version makes trouble when tf-nighly is installed locally. I try to reroute any version number including 'dev', that does not have correponding base image, to tf-nightly. 

#29 