### PR TITLE
self.assertTrue(... in ...) to self.assertIn

### DIFF
--- a/tests/tensorflow_cloud/containerize_test.py
+++ b/tests/tensorflow_cloud/containerize_test.py
@@ -137,7 +137,7 @@ class TestContainerize(unittest.TestCase):
         # Verify value error is raised
         with self.assertRaises(ValueError) as context:
             lcb._create_docker_file()
-        self.assertTrue("base image" in str(context.exception))
+        self.assertIn("base image", str(context.exception))
 
     def test_check_docker_base_image_nightly(self):
         self.setup()


### PR DESCRIPTION
self.assertIn(..., ...) will give more detailed error information than self.assertTrue(... in ...).

https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertIn