### PR TITLE
Change default GPU to Nvidia Tesla T4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ tfc.run(
     chief_config=tfc.MachineConfig(
             cpu_cores=8,
             memory=30,
-            accelerator_type=tfc.AcceleratorType.NVIDIA_TESLA_P100,
+            accelerator_type=tfc.AcceleratorType.NVIDIA_TESLA_T4,
             accelerator_count=2),
     worker_count=0)
 
@@ -279,7 +279,7 @@ tfc.run(entry_point='mnist_example.py',
 
 ***OneDeviceStrategy***
 
-1 GPU on chief (defaults to `AcceleratorType.NVIDIA_TESLA_P100`) and no additional workers. 
+1 GPU on chief (defaults to `AcceleratorType.NVIDIA_TESLA_T4`) and no additional workers. 
 
 ```python
 tfc.run(entry_point='mnist_example.py')

--- a/tensorflow_cloud/machine_config.py
+++ b/tensorflow_cloud/machine_config.py
@@ -64,7 +64,7 @@ class MachineConfig(object):
       accelerator_type: Type of the accelerator to be used
         ('K80', 'P100', 'V100', 'P4', 'T4', 'TPU_V2', 'TPU_V3') or 'CPU'
         for no accelerator. Defaults to `auto`, which maps to a standard
-        gpu config such as 'P100'.
+        gpu config such as 'T4'.
       accelerator_count: Number of accelerators. Defaults to 1.
     """
 

--- a/tensorflow_cloud/run.py
+++ b/tensorflow_cloud/run.py
@@ -92,15 +92,15 @@ def run(
         chief_config: Optional `MachineConfig` that represents the
             configuration for the chief worker in a distribution cluster.
             Defaults to 'auto'. 'auto' maps to a standard gpu config such as
-            `COMMON_MACHINE_CONFIGS.P100_1X` (8 cpu cores, 30GB memory,
-            1 Nvidia Tesla P100).
+            `COMMON_MACHINE_CONFIGS.T4_1X` (8 cpu cores, 30GB memory,
+            1 Nvidia Tesla T4).
             For TPU strategy, `chief_config` refers to the config of the host
             that controls the TPU workers.
         worker_config: Optional `MachineConfig` that represents the
             configuration for the general workers in a distribution cluster.
             Defaults to 'auto'. 'auto' maps to a standard gpu config such as
-            `COMMON_MACHINE_CONFIGS.P100_1X` (8 cpu cores, 30GB memory,
-            1 Nvidia Tesla P100).
+            `COMMON_MACHINE_CONFIGS.T4_1X` (8 cpu cores, 30GB memory,
+            1 Nvidia Tesla T4).
             For TPU strategy, `worker_config` should be a TPU config with 
             8 TPU cores (eg. `COMMON_MACHINE_CONFIGS.TPU`).
         worker_count: Optional integer that represents the number of general
@@ -147,9 +147,9 @@ def run(
     # package is required to be installed in addition to the user provided
     # packages.
     if chief_config == "auto":
-        chief_config = machine_config.COMMON_MACHINE_CONFIGS["P100_1X"]
+        chief_config = machine_config.COMMON_MACHINE_CONFIGS["T4_1X"]
     if worker_config == "auto":
-        worker_config = machine_config.COMMON_MACHINE_CONFIGS["P100_1X"]
+        worker_config = machine_config.COMMON_MACHINE_CONFIGS["T4_1X"]
     region = gcp.get_region()
     # Working directory in the docker container filesystem.
     destination_dir = "/app/"

--- a/tests/integration/call_run_on_notebook_with_keras_fit_test.py
+++ b/tests/integration/call_run_on_notebook_with_keras_fit_test.py
@@ -25,7 +25,7 @@ tfc.run(
     chief_config=tfc.MachineConfig(
         cpu_cores=8,
         memory=30,
-        accelerator_type=tfc.AcceleratorType.NVIDIA_TESLA_P100,
+        accelerator_type=tfc.AcceleratorType.NVIDIA_TESLA_T4,
         accelerator_count=2,
     ),
     worker_count=0,

--- a/tests/integration/call_run_on_script_with_keras_fit_cloud_build_test.py
+++ b/tests/integration/call_run_on_script_with_keras_fit_cloud_build_test.py
@@ -30,7 +30,7 @@ tfc.run(
     chief_config=tfc.MachineConfig(
         cpu_cores=8,
         memory=30,
-        accelerator_type=tfc.AcceleratorType.NVIDIA_TESLA_P100,
+        accelerator_type=tfc.AcceleratorType.NVIDIA_TESLA_T4,
         accelerator_count=2,
     ),
     worker_count=0,

--- a/tests/integration/call_run_on_script_with_keras_fit_test.py
+++ b/tests/integration/call_run_on_script_with_keras_fit_test.py
@@ -34,24 +34,24 @@ import tensorflow_cloud as tfc
 #     stream_logs=True)
 
 # Automated MirroredStrategy: chief config with multiple GPUs
-# tfc.run(
-#     entry_point='tests/testdata/mnist_example_using_fit.py',
-#     distribution_strategy='auto',
-#     requirements_txt='tests/testdata/requirements.txt',
-#     chief_config=tfc.MachineConfig(
-#             cpu_cores=8,
-#             memory=30,
-#             accelerator_type=tfc.AcceleratorType.NVIDIA_TESLA_P100,
-#             accelerator_count=2),
-#     worker_count=0,
-#     stream_logs=True)
+tfc.run(
+    entry_point='tests/testdata/mnist_example_using_fit.py',
+    distribution_strategy='auto',
+    requirements_txt='tests/testdata/requirements.txt',
+    chief_config=tfc.MachineConfig(
+            cpu_cores=8,
+            memory=30,
+            accelerator_type=tfc.AcceleratorType.NVIDIA_TESLA_T4,
+            accelerator_count=2),
+    worker_count=0,
+    stream_logs=True)
 
 # Automated TPUStrategy
-tfc.run(
-    entry_point="tests/testdata/mnist_example_using_fit_no_reqs.py",
-    distribution_strategy="auto",
-    chief_config=tfc.COMMON_MACHINE_CONFIGS["CPU"],
-    worker_count=1,
-    worker_config=tfc.COMMON_MACHINE_CONFIGS["TPU"],
-    stream_logs=True,
-)
+# tfc.run(
+#     entry_point="tests/testdata/mnist_example_using_fit_no_reqs.py",
+#     distribution_strategy="auto",
+#     chief_config=tfc.COMMON_MACHINE_CONFIGS["CPU"],
+#     worker_count=1,
+#     worker_config=tfc.COMMON_MACHINE_CONFIGS["TPU"],
+#     stream_logs=True,
+# )

--- a/tests/integration/call_run_within_nb_on_colab.ipynb
+++ b/tests/integration/call_run_within_nb_on_colab.ipynb
@@ -377,7 +377,7 @@
     "    chief_config=tfc.MachineConfig(\n",
     "        cpu_cores=8,\n",
     "        memory=30,\n",
-    "        accelerator_type=tfc.AcceleratorType.NVIDIA_TESLA_P100,\n",
+    "        accelerator_type=tfc.AcceleratorType.NVIDIA_TESLA_T4,\n",
     "        accelerator_count=2,\n",
     "    ),\n",
     "    docker_image_bucket_name=BUCKET_NAME,\n",

--- a/tests/integration/call_run_within_script_with_keras_fit_test.py
+++ b/tests/integration/call_run_within_script_with_keras_fit_test.py
@@ -38,7 +38,7 @@ tfc.run(
     chief_config=tfc.MachineConfig(
         cpu_cores=8,
         memory=30,
-        accelerator_type=tfc.AcceleratorType.NVIDIA_TESLA_P100,
+        accelerator_type=tfc.AcceleratorType.NVIDIA_TESLA_T4,
         accelerator_count=2,
     ),
     worker_count=0,


### PR DESCRIPTION
Cloud AI started recommending users to use NVIDIA T4 for cost efficiency for
both training and serving and AMP(Automatic Mixed Precision) support: https://cloud.google.com/blog/products/ai-machine-learning/your-ml-workloads-cheaper-and-faster-with-the-latest-gpus

Based on https://github.com/tensorflow/cloud/pull/14. 