### PR TITLE
Use TF:latest docker image when the given image is unavailable.

### DIFF
--- a/src/python/tensorflow_cloud/core/containerize.py
+++ b/src/python/tensorflow_cloud/core/containerize.py
@@ -150,12 +150,12 @@ class ContainerBuilder(object):
                     self.docker_base_image += "-py3"
 
         if not self._base_image_exist():
+            warnings.warn(
+                "Docker base image {} does not exist.".format(self.docker_base_image)
+            )
             if "dev" in self.docker_base_image:
-                warnings.warn(
-                    "Docker base image {} does not exist.".format(
-                        self.docker_base_image
-                    )
-                )
+                # Except for the latest TF nightly, other nightlies
+                # do not have corresponding docker images.
                 newtag = "nightly"
                 if self.docker_base_image.endswith("-gpu"):
                     newtag += "-gpu"
@@ -164,11 +164,16 @@ class ContainerBuilder(object):
                 )
                 warnings.warn("Using the latest TF nightly build.")
             else:
-                raise ValueError(
-                    "There is no docker base image corresponding to the local "
-                    "TF version: {}. Please provide docker_base_image or try "
-                    "with an other TF version.".format(VERSION)
+                warnings.warn(
+                    "Using the latest stable TF docker image available: "
+                    "`tensorflow/tensorflow:latest`"
+                    "Please see https://hub.docker.com/r/tensorflow/tensorflow/ "
+                    "for details on available docker images."
                 )
+                newtag = "tensorflow/tensorflow:latest"
+                if self.docker_base_image.endswith("-gpu"):
+                    newtag += "-gpu"
+                self.docker_base_image = newtag
 
         lines = [
             "FROM {}".format(self.docker_base_image),

--- a/src/python/tensorflow_cloud/tests/core/containerize_test.py
+++ b/src/python/tensorflow_cloud/tests/core/containerize_test.py
@@ -122,25 +122,6 @@ class TestContainerize(unittest.TestCase):
         self.assert_docker_file(expected_docker_file_lines, lcb.docker_file_path)
         self.cleanup(lcb.docker_file_path)
 
-    def test_check_docker_base_image_non_exist(self):
-        self.setup()
-        lcb = containerize.LocalContainerBuilder(
-            self.entry_point,
-            None,
-            self.chief_config,
-            self.worker_config,
-            self.mock_registry,
-            self.project_id,
-            docker_base_image="tensorflow/tensorflow:2.100.0",
-        )
-        # Verify the docker base image is identified as nonexist
-        self.assertTrue(not lcb._base_image_exist())
-
-        # Verify value error is raised
-        with self.assertRaises(ValueError) as context:
-            lcb._create_docker_file()
-        self.assertIn("base image", str(context.exception))
-
     def test_check_docker_base_image_nightly(self):
         self.setup()
         lcb = containerize.LocalContainerBuilder(
@@ -152,13 +133,38 @@ class TestContainerize(unittest.TestCase):
             self.project_id,
             docker_base_image="tensorflow/tensorflow:2.3.0-dev20200605",
         )
-        # Verify the docker base image is identified as nonexist
+        # Verify the docker base image is identified as nonexistent
         self.assertTrue(not lcb._base_image_exist())
 
-        # Verify the dockerfile ask for tfnightly
+        # Verify that the dockerfile fetches the latest tfnightly
         lcb._create_docker_file()
         expected_docker_file_lines = [
             "FROM tensorflow/tensorflow:nightly\n",
+            "WORKDIR /app/\n",
+            "COPY /app/ /app/\n",
+            'ENTRYPOINT ["python", "mnist_example_using_fit.py"]',
+        ]
+        self.assert_docker_file(expected_docker_file_lines, lcb.docker_file_path)
+        self.cleanup(lcb.docker_file_path)
+
+    def test_check_nonexistent_docker_image(self):
+        self.setup()
+        lcb = containerize.LocalContainerBuilder(
+            self.entry_point,
+            None,
+            self.chief_config,
+            self.worker_config,
+            self.mock_registry,
+            self.project_id,
+            docker_base_image="tensorflow/tensorflow:21",
+        )
+        # Verify the docker base image is identified as nonexistent
+        self.assertTrue(not lcb._base_image_exist())
+
+        # Verify that the dockerfile fetches the latest stable image
+        lcb._create_docker_file()
+        expected_docker_file_lines = [
+            "FROM tensorflow/tensorflow:latest\n",
             "WORKDIR /app/\n",
             "COPY /app/ /app/\n",
             'ENTRYPOINT ["python", "mnist_example_using_fit.py"]',


### PR DESCRIPTION
Raise warning and use tf:latest docker image instead of raising an error when a given image is unavailable.