### PR TITLE
Close temporary files before removal, fix PermissionError

### DIFF
--- a/src/python/tensorflow_cloud/core/containerize.py
+++ b/src/python/tensorflow_cloud/core/containerize.py
@@ -124,6 +124,10 @@ class ContainerBuilder(object):
 
         Args:
             return_descriptors: Whether to return descriptors as well.
+        
+        Returns:
+          Docker and tar file paths. Depending on return_descriptors, possibly
+          their file descriptors as well. 
         """
         if return_descriptors:
           return [

--- a/src/python/tensorflow_cloud/core/containerize.py
+++ b/src/python/tensorflow_cloud/core/containerize.py
@@ -135,7 +135,7 @@ class ContainerBuilder(object):
                 (self.tar_file_path, self.tar_file_descriptor)
             ]
         else:
-          return [self.docker_file_path, self.tar_file_path]
+            return [self.docker_file_path, self.tar_file_path]
 
     def _get_tar_file_path(self):
         """Packages files into a tarball."""

--- a/src/python/tensorflow_cloud/core/containerize.py
+++ b/src/python/tensorflow_cloud/core/containerize.py
@@ -103,6 +103,8 @@ class ContainerBuilder(object):
         # Those will be populated lazily.
         self.tar_file_path = None
         self.docker_client = None
+        self.tar_file_descriptor = None
+        self.docker_file_descriptor = None
 
     def get_docker_image(
         self, max_status_check_attempts=None, delay_between_status_checks=None
@@ -117,15 +119,26 @@ class ContainerBuilder(object):
         """
         raise NotImplementedError
 
-    def get_generated_files(self):
-        return [self.docker_file_path, self.tar_file_path]
+    def get_generated_files(self, return_descriptors=False):
+        """Get generated file paths and/or descriptors for generated files.
+
+        Args:
+            return_descriptors: Whether to return descriptors as well.
+        """
+        if return_descriptors:
+          return [
+            (self.docker_file_path, self.docker_file_descriptor),
+            (self.tar_file_path, self.tar_file_descriptor)
+          ]
+        else:
+          return [self.docker_file_path, self.tar_file_path]
 
     def _get_tar_file_path(self):
         """Packages files into a tarball."""
         self._create_docker_file()
         file_path_map = self._get_file_path_map()
 
-        _, self.tar_file_path = tempfile.mkstemp()
+        self.tar_file_descriptor, self.tar_file_path = tempfile.mkstemp()
         with tarfile.open(self.tar_file_path, "w:gz", dereference=True) as tar:
             for source, destination in file_path_map.items():
                 tar.add(source, arcname=destination)
@@ -233,7 +246,7 @@ class ContainerBuilder(object):
         )
 
         content = "\n".join(lines)
-        _, self.docker_file_path = tempfile.mkstemp()
+        self.docker_file_descriptor, self.docker_file_path = tempfile.mkstemp()
         with open(self.docker_file_path, "w") as f:
             f.write(content)
 

--- a/src/python/tensorflow_cloud/core/containerize.py
+++ b/src/python/tensorflow_cloud/core/containerize.py
@@ -124,16 +124,16 @@ class ContainerBuilder(object):
 
         Args:
             return_descriptors: Whether to return descriptors as well.
-        
+
         Returns:
           Docker and tar file paths. Depending on return_descriptors, possibly
-          their file descriptors as well. 
+          their file descriptors as well.
         """
         if return_descriptors:
-          return [
-            (self.docker_file_path, self.docker_file_descriptor),
-            (self.tar_file_path, self.tar_file_descriptor)
-          ]
+            return [
+                (self.docker_file_path, self.docker_file_descriptor),
+                (self.tar_file_path, self.tar_file_descriptor)
+            ]
         else:
           return [self.docker_file_path, self.tar_file_path]
 

--- a/src/python/tensorflow_cloud/core/preprocess.py
+++ b/src/python/tensorflow_cloud/core/preprocess.py
@@ -111,7 +111,7 @@ def get_preprocessed_entry_point(
 
     Raises:
         RuntimeError: If invoked from Notebook but unable to access it.
-                      Typically, this is due to missing the `nbconvert` package.
+            Typically, this is due to missing the `nbconvert` package.
     """
 
     # Set `TF_KERAS_RUNNING_REMOTELY` env variable. This is required in order

--- a/src/python/tensorflow_cloud/core/preprocess.py
+++ b/src/python/tensorflow_cloud/core/preprocess.py
@@ -193,7 +193,7 @@ def get_preprocessed_entry_point(
     file_descriptor, output_file = tempfile.mkstemp(suffix=".py")
     with open(output_file, "w") as f:
         f.writelines(script_lines)
-        
+
     # Returning file descriptor could be necessary for some os.close calls
     if return_file_descriptor:
       return (output_file, file_descriptor)

--- a/src/python/tensorflow_cloud/core/preprocess.py
+++ b/src/python/tensorflow_cloud/core/preprocess.py
@@ -103,7 +103,7 @@ def get_preprocessed_entry_point(
             `worker_count` params.
         called_from_notebook: Boolean. True if the API is run in a
             notebook environment.
-        return_file_descriptor: Boolean. True if the file descriptor for the 
+        return_file_descriptor: Boolean. True if the file descriptor for the
             temporary file is also returned.
 
     Returns:

--- a/src/python/tensorflow_cloud/core/preprocess.py
+++ b/src/python/tensorflow_cloud/core/preprocess.py
@@ -42,6 +42,7 @@ def get_preprocessed_entry_point(
     worker_count,
     distribution_strategy,
     called_from_notebook=False,
+    return_file_descriptor=False
 ):
     """Creates python script for distribution based on the given `entry_point`.
 
@@ -102,6 +103,8 @@ def get_preprocessed_entry_point(
             `worker_count` params.
         called_from_notebook: Boolean. True if the API is run in a
             notebook environment.
+        return_file_descriptor: Boolean. True if the file descriptor for the 
+            temporary file is also returned.
 
     Returns:
         The `preprocessed_entry_point` file path.
@@ -190,7 +193,12 @@ def get_preprocessed_entry_point(
     _, output_file = tempfile.mkstemp(suffix=".py")
     with open(output_file, "w") as f:
         f.writelines(script_lines)
-    return output_file
+        
+    # Returning file descriptor could be necessary for some os.close calls
+    if return_file_descriptor:
+      return (output_file, file_descriptor)
+    else:
+      return output_file
 
 
 def _get_colab_notebook_content():

--- a/src/python/tensorflow_cloud/core/preprocess.py
+++ b/src/python/tensorflow_cloud/core/preprocess.py
@@ -190,7 +190,7 @@ def get_preprocessed_entry_point(
                 script_lines.append(line)
 
     # Create a tmp wrapped entry point script file.
-    _, output_file = tempfile.mkstemp(suffix=".py")
+    file_descriptor, output_file = tempfile.mkstemp(suffix=".py")
     with open(output_file, "w") as f:
         f.writelines(script_lines)
         

--- a/src/python/tensorflow_cloud/core/run.py
+++ b/src/python/tensorflow_cloud/core/run.py
@@ -228,7 +228,8 @@ def run(
     if preprocessed_entry_point is not None:
         os.close(pep_file_descriptor)
         os.remove(preprocessed_entry_point)
-    for file_path, file_descriptor in container_builder.get_generated_files(return_descriptors=True):
+    for file_path, file_descriptor \
+        in container_builder.get_generated_files(return_descriptors=True):
         os.close(file_descriptor)
         os.remove(file_path)
 

--- a/src/python/tensorflow_cloud/core/run.py
+++ b/src/python/tensorflow_cloud/core/run.py
@@ -192,7 +192,8 @@ def run(
     if (distribution_strategy == "auto"
         or entry_point.endswith("ipynb")
         or entry_point is None):
-        preprocessed_entry_point, pep_file_descriptor = preprocess.get_preprocessed_entry_point(
+        preprocessed_entry_point, \
+          pep_file_descriptor = preprocess.get_preprocessed_entry_point(
             entry_point,
             chief_config,
             worker_config,

--- a/src/python/tensorflow_cloud/core/run.py
+++ b/src/python/tensorflow_cloud/core/run.py
@@ -194,14 +194,14 @@ def run(
         or entry_point is None):
         preprocessed_entry_point, \
           pep_file_descriptor = preprocess.get_preprocessed_entry_point(
-            entry_point,
-            chief_config,
-            worker_config,
-            worker_count,
-            distribution_strategy,
-            called_from_notebook=called_from_notebook,
-            return_file_descriptor=True,
-        )
+              entry_point,
+              chief_config,
+              worker_config,
+              worker_count,
+              distribution_strategy,
+              called_from_notebook=called_from_notebook,
+              return_file_descriptor=True,
+          )
 
     # Create Docker file, generate a tarball, build and push Docker
     # image using the tarball.


### PR DESCRIPTION
Fixes #123.

TensorFlow Cloud creates temporary files which it then removes out of neatness reasons, but on Windows a `PermissionError` emerges because the files haven't been closed before removal.

This PR fixes the issue by closing the temporary files using their file descriptors before attempting to remove them. In doing so, I attempted to keep the existing definitions backwards compatible by making returning the file descriptors optional.

