### PR TITLE
Add option to specify jobDir param.

### DIFF
--- a/src/python/tensorflow_cloud/core/deploy.py
+++ b/src/python/tensorflow_cloud/core/deploy.py
@@ -33,6 +33,7 @@ def deploy_job(
     entry_point_args,
     enable_stream_logs,
     job_labels=None,
+    job_dir=None,
 ):
     """Deploys job with the given parameters to Google Cloud.
 
@@ -51,6 +52,7 @@ def deploy_job(
             back from the cloud job.
         job_labels: Dict of str: str. Labels to organize jobs. See
             https://cloud.google.com/ai-platform/training/docs/resource-labels.
+        job_dir: Optional. A Google Cloud Storage path in which to store training outputs.
 
     Returns:
         ID of the invoked remote Cloud AI Platform job.
@@ -76,6 +78,7 @@ def deploy_job(
         worker_config,
         entry_point_args,
         job_labels=job_labels or {},
+        job_dir=job_dir
     )
     try:
         unused_response = (
@@ -102,6 +105,7 @@ def _create_request_dict(
     worker_config,
     entry_point_args,
     job_labels,
+    job_dir,
 ):
     """Creates request dictionary for the CAIP training service."""
     training_input = {}
@@ -159,6 +163,8 @@ def _create_request_dict(
     training_input["use_chief_in_tf_config"] = True
     request_dict = {}
     request_dict["jobId"] = job_id
+    if job_dir:
+        training_input["jobDir"] = job_dir     
     request_dict["trainingInput"] = training_input
     if job_labels:
         request_dict["labels"] = job_labels

--- a/src/python/tensorflow_cloud/core/run.py
+++ b/src/python/tensorflow_cloud/core/run.py
@@ -44,6 +44,7 @@ def run(
     entry_point_args=None,
     stream_logs=False,
     job_labels=None,
+    job_dir=None,
     **kwargs
 ):
     """Runs your Tensorflow code in Google Cloud Platform.
@@ -117,6 +118,7 @@ def run(
             up to 64 key-value pairs in lowercase letters and numbers, where
             the first character must be lowercase letter. For more details see
             https://cloud.google.com/ai-platform/training/docs/resource-labels.
+        job_dir: Optional. A Google Cloud Storage path in which to store training outputs.
         **kwargs: Additional keyword arguments.
 
     Returns:
@@ -240,6 +242,7 @@ def run(
         entry_point_args,
         stream_logs,
         job_labels=job_labels,
+        job_dir=job_dir,
     )
 
     # Call `exit` to prevent training the Keras model in the local env.


### PR DESCRIPTION
Fixes partially #245 (missing the Deploy Model option).

Enable "Download Model" in AI Platform UI. The user is still responsible to save files to this bucket as part of their script. This only enables the link to GCS in the UI.

ML API reference:
https://cloud.google.com/ai-platform/training/docs/reference/rest/v1/projects.jobs#Job

![8Z5MVnY9Ndid2Hg](https://user-images.githubusercontent.com/1190441/98428641-3ea24e80-2057-11eb-80cc-9a4ecc86c65e.png)
