### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/src/python/tensorflow_cloud/tuner/tuner.py
+++ b/src/python/tensorflow_cloud/tuner/tuner.py
@@ -301,7 +301,7 @@ class CloudOracle(oracle_module.Oracle):
     def get_best_trials(self, num_trials: int = 1) -> List[trial_module.Trial]:
         """Returns the trials with the best objective values found so far.
 
-        Arguments:
+        Args:
             num_trials: positive int, number of trials to return.
         Returns:
             List of KerasTuner Trials.
@@ -501,7 +501,7 @@ class DistributingCloudTuner(tuner_module.Tuner):
 
         This method is called during `search` to evaluate a set of
         hyperparameters using AI Platform training.
-        Arguments:
+        Args:
             trial: A `Trial` instance that contains the information
               needed to run this trial. `Hyperparameters` can be accessed
               via `trial.hyperparameters`.
@@ -637,7 +637,7 @@ class DistributingCloudTuner(tuner_module.Tuner):
     def _get_job_spec_from_config(self, job_id: Text) -> Dict[Text, Any]:
         """Creates a request dictionary for the CAIP training service.
 
-        Arguments:
+        Args:
             job_id: Job name that will be used for AIP training
         Returns:
             An AI Platform Training job spec.
@@ -681,7 +681,7 @@ class DistributingCloudTuner(tuner_module.Tuner):
         All complete epochs metrics (including the last epoch if applicable) are
         returned as training_metrics.
 
-        Arguments:
+        Args:
             log_reader: An instance of tensorboard DirectoryWatcher that is
                 pointing to the tensorboard logs directory.
             partial_epoch_metrics: Any incomplete epoch metrics from previous
@@ -742,7 +742,7 @@ class DistributingCloudTuner(tuner_module.Tuner):
         TensorBoard callback to pass back the epoch related metrics from
         remote execution.
 
-        Arguments:
+        Args:
             callbacks: List of callbacks passed in to the search function.
             trial: A `Trial` instance.
         Raises:

--- a/src/python/tensorflow_cloud/tuner/utils.py
+++ b/src/python/tensorflow_cloud/tuner/utils.py
@@ -52,7 +52,7 @@ def make_study_config(
     hyperparams: hp_module.HyperParameters) -> Dict[Text, Any]:
     """Generates Optimizer study_config from kerastuner configurations.
 
-    Arguments:
+    Args:
         objective: String or `oracle_module.Objective`. If a string,
             the direction of the optimization (min or max) will be inferred.
         hyperparams: HyperParameters class instance. Can be used to override (or
@@ -383,7 +383,7 @@ def format_objective(
     direction: Text = None) -> List[oracle_module.Objective]:
     """Formats objective to a list of oracle_module.Objective.
 
-    Arguments:
+    Args:
         objective: If a string, the direction of the optimization (min or max)
             will be inferred.
         direction: Optional. e.g. 'min' or 'max'.
@@ -456,7 +456,7 @@ def _get_scale_type(sampling):
 def get_trial_id(optimizer_trial: Dict[Text, Any]) -> Text:
     r"""Gets trial_id from a CAIP Optimizer Trial.
 
-    Arguments:
+    Args:
         optimizer_trial: A CAIP Optimizer Trial instance.
 
     Returns:
@@ -472,7 +472,7 @@ def convert_optimizer_trial_to_dict(
 ) -> Dict[Text, Any]:
     """Converts Optimizer Trial parameters into a Python dict.
 
-    Arguments:
+    Args:
         optimizer_trial: A CAIP Optimizer Trial instance.
 
     Returns:
@@ -496,7 +496,7 @@ def convert_optimizer_trial_to_hps(
 ) -> hp_module.HyperParameters:
     """Converts Optimizer Trial parameters into KerasTuner HyperParameters.
 
-    Arguments:
+    Args:
         hps: Sample KerasTuner HyperParameters object for config initialization
         optimizer_trial: A CAIP Optimizer Trial instance.
 
@@ -515,7 +515,7 @@ def convert_completed_optimizer_trial_to_keras_trial(
 ) -> trial_module.Trial:
     """Converts completed Optimizer Trial into KerasTuner Trial.
 
-    Arguments:
+    Args:
         optimizer_trial: A CAIP Optimizer Trial Instance.
         hyperparameter_space: Mandatory and must include definitions for all
             hyperparameters used during the search.


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420