### PR TITLE
fix(docs): updates link in project README currently returning 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ object already used in your code.
 
 We welcome community contributions, see [CONTRIBUTING.md](CONTRIBUTING.md) and,
 for style help,
-[Writing TensorFlow documentation](https://www.tensorflow.org/community/documentation)
+[Writing TensorFlow documentation](https://www.tensorflow.org/community/contribute/docs_style)
 guide.
 
 ## License


### PR DESCRIPTION
Scope of changes is restricted to docs only.
Old URL in project README, returning 404 status code, replaced with current URL for TensorFlow documentation style guide

https://www.tensorflow.org/community/documentation
  =>   https://www.tensorflow.org/community/contribute/docs_style